### PR TITLE
Add DI for Request object.

### DIFF
--- a/src/Plugin/Block/PrintableLinksBlock.php
+++ b/src/Plugin/Block/PrintableLinksBlock.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\printable\Plugin\Block;
 
+// @todo Remove use statements of unused classes.
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Block\Annotation\Block;
 use Drupal\Core\Annotation\Translation;
@@ -26,6 +27,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * )
  */
 class PrintableLinksBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
   /**
    * The request service.
    *
@@ -45,10 +47,11 @@ class PrintableLinksBlock extends BlockBase implements ContainerFactoryPluginInt
    *
    * @param \Drupal\printable\PrintableLinkBuilderInterface $link_builder
    *   The printable link builder.
+   * @todo Update parameters
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, PrintableLinkBuilderInterface $link_builder) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, Request $request, PrintableLinkBuilderInterface $link_builder) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->request = \Drupal::request();
+    $this->request = $request;
     $this->linkBuilder = $link_builder;
   }
 
@@ -57,7 +60,10 @@ class PrintableLinksBlock extends BlockBase implements ContainerFactoryPluginInt
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
-      $configuration, $plugin_id, $plugin_definition,
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('request_stack')->getCurrentRequest(),
       $container->get('printable.link_builder')
     );
   }


### PR DESCRIPTION
This is how I would add DI for the Request object. I leave the replacement of Drupal::routeMatch() to you.
My recipe:
- Look inside the procedural function (Drupal::request()) and locate the code that does the work (static::getContainer()->get('request_stack')->getCurrentRequest()).
- Use this code and the $container object to construct a loader in the create() method ($container->get('request_stack')->getCurrentRequest())
- Add a parameter to __construct() to received the object (Request $request).
- Add a use statement to enable autoloading of the used class (use Symfony\Component\HttpFoundation\Request)
- Save the object inside the object ($this->request = $request)
- For better development experience, make sure the order of the parameters in __construct() and create() is the same.