### PR TITLE
Automatic code style corrections using phpcbf.

### DIFF
--- a/css/entity-links.css
+++ b/css/entity-links.css
@@ -1,13 +1,12 @@
 .node_view ul {
-	list-style-type: none;
+  list-style-type: none;
 }
 .node_view a {
-	text-decoration: none;
+  text-decoration: none;
 }
 .node_view ul.tryhere li:first-child {
-    /** the image will be vertically aligned in the center **/
-    background: url(../icons/print_icon.png) left center no-repeat;
-
-    /** move the text to the right **/
-    padding-left: 20px;
+  /** the image will be vertically aligned in the center **/
+  background: url(../icons/print_icon.png) left center no-repeat;
+  /** move the text to the right **/
+  padding-left: 20px;
 }

--- a/js/close.js
+++ b/js/close.js
@@ -1,4 +1,7 @@
+/**
+ * @file
+ */
 document.addEventListener('DOMContentLoaded',function(){
-	window.print();
-	window.close();
+  window.print();
+  window.close();
 });

--- a/js/script.js
+++ b/js/script.js
@@ -1,3 +1,6 @@
+/**
+ * @file
+ */
 document.addEventListener('DOMContentLoaded',function(){
-	window.print();
+  window.print();
 });

--- a/src/Form/LinksConfigurationForm.php
+++ b/src/Form/LinksConfigurationForm.php
@@ -63,7 +63,7 @@ class LinksConfigurationForm extends FormBase {
 
     $form['settings']['print_print_link_pos'] = array(
       '#type' => 'checkboxes',
-      '#title' =>'Link location',
+      '#title' => 'Link location',
       '#default_value' => array(),
       '#options' => array('node' => $this->t('Links area'), 'comment' => $this->t('Comment area'), 'user' => $this->t('User area')),
       '#description' => $this->t('Choose the location of the link(s) to the printer-friendly version pages. The Links area is usually below the node content, whereas the Comment area is placed near the comments. The user area is near the user name. Select the options for which you want to enable the link. If you select any option then it means that you have enabled printable support for that entity in the configuration tab.'),

--- a/src/Form/PdfLinksConfigurationForm.php
+++ b/src/Form/PdfLinksConfigurationForm.php
@@ -63,7 +63,7 @@ class PdfLinksConfigurationForm extends FormBase {
 
     $form['settings']['print_pdf_link_pos'] = array(
       '#type' => 'checkboxes',
-      '#title' =>'Link location',
+      '#title' => 'Link location',
       '#default_value' => array(),
       '#options' => array('node' => $this->t('Links area'), 'comment' => $this->t('Comment area'), 'user' => $this->t('User area')),
       '#description' => $this->t('Choose the location of the link(s) to the printer-friendly version pages. The Links area is usually below the node content, whereas the Comment area is placed near the comments. The user area is near the user name. Select the options for which you want to disable the link. If you select any option then it means that you have enabled printable support for that entity in the configuration tab.'),

--- a/src/LinkExtractor/InlineLinkExtractor.php
+++ b/src/LinkExtractor/InlineLinkExtractor.php
@@ -74,7 +74,7 @@ class InlineLinkExtractor implements LinkExtractorInterface {
     $this->crawler->filter('a')->each(function(HtmlPageCrawler $anchor, $uri) {
       $href = $anchor->attr('href');
       // @todo deprecated method.
-      $this->links[] =  $this->urlGenerator->generateFromPath($href, array('absolute' => TRUE));
+      $this->links[] = $this->urlGenerator->generateFromPath($href, array('absolute' => TRUE));
     });
     $this->crawler->remove();
     return implode(',', $this->links);

--- a/src/LinkExtractor/LinkExtractorInterface.php
+++ b/src/LinkExtractor/LinkExtractorInterface.php
@@ -17,7 +17,7 @@ interface LinkExtractorInterface {
    *
    * @param string $string
    *   The HTML string to extract links from.
-   *   
+   *
    * @return string
    *   The HTML string, with links highlighted.
    */

--- a/src/Plugin/Block/PrintableLinksBlock.php
+++ b/src/Plugin/Block/PrintableLinksBlock.php
@@ -60,7 +60,7 @@ class PrintableLinksBlock extends BlockBase implements ContainerFactoryPluginInt
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
       $configuration,
-      $plugin_id, 
+      $plugin_id,
       $plugin_definition,
       $container->get('current_route_match'),
       $container->get('printable.link_builder')
@@ -71,7 +71,7 @@ class PrintableLinksBlock extends BlockBase implements ContainerFactoryPluginInt
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-  	
+
     $form += parent::buildConfigurationForm($form, $form_state);
     $period = array(0, 60, 180, 300, 600, 900, 1800, 2700, 3600, 10800, 21600, 32400, 43200, 86400);
     $period = array_map(array(\Drupal::service('date.formatter'), 'formatInterval'), array_combine($period, $period));
@@ -88,7 +88,7 @@ class PrintableLinksBlock extends BlockBase implements ContainerFactoryPluginInt
       '#default_value' => $period[0],
       '#options' => $period,
     );
-  	return $form;
+    return $form;
   }
 
   /**
@@ -103,7 +103,8 @@ class PrintableLinksBlock extends BlockBase implements ContainerFactoryPluginInt
         '#links' => $this->linkBuilder->buildLinks($this->routeMatch->getMasterRouteMatch()->getParameter($entity_type)),
         '#cache' => array(
           'tags' => $config->getCacheTags(),
-          'max-age' => 0),
+          'max-age' => 0,
+        ),
       );
     }
   }

--- a/src/Plugin/Derivative/PrintableFormatConfigureTabs.php
+++ b/src/Plugin/Derivative/PrintableFormatConfigureTabs.php
@@ -51,7 +51,7 @@ class PrintableFormatConfigureTabs extends DeriverBase implements ContainerDeriv
       $this->derivatives[$key] = $base_plugin_definition;
       $this->derivatives[$key]['title'] = $definition['title'];
       $this->derivatives[$key]['route_parameters'] = array('printable_format' => $key);
-      $this->derivatives[$key]['route_name'] = 'printable.format_configure_'. $key;
+      $this->derivatives[$key]['route_name'] = 'printable.format_configure_' . $key;
     }
     return $this->derivatives;
   }

--- a/src/PrintableEntityManager.php
+++ b/src/PrintableEntityManager.php
@@ -50,13 +50,13 @@ class PrintableEntityManager implements PrintableEntityManagerInterface {
     $this->configFactory = $config_factory;
   }
 
-   /**
-   * {@inheritdoc}
-   */
-   public function getEntityName(EntityInterface $entity) {
-     return $entity->getEntityTypeId();
-   }
-   
+  /**
+    * {@inheritdoc}
+    */
+  public function getEntityName(EntityInterface $entity) {
+    return $entity->getEntityTypeId();
+  }
+
   /**
    * {@inheritdoc}
    */

--- a/src/PrintableEntityManagerInterface.php
+++ b/src/PrintableEntityManagerInterface.php
@@ -14,15 +14,15 @@ use Drupal\Core\Entity\EntityInterface;
  */
 interface PrintableEntityManagerInterface {
 
-   /**
-   * Gets the ID of the type of the entity.
-   *
-   * @param EntityInterface $entity
-   *   The entity to check a printable version is available for.
-   *
-   * @return string
-   *   The entity type ID.
-   */
+  /**
+    * Gets the ID of the type of the entity.
+    *
+    * @param EntityInterface $entity
+    *   The entity to check a printable version is available for.
+    *
+    * @return string
+    *   The entity type ID.
+    */
   public function getEntityName(EntityInterface $entity);
 
   /**


### PR DESCRIPTION
I advise to look at the differences in the PR to learn how to improve the code style in the future.
There are more code style violations, you can find them with:
```
phpcs --standard=Drupal /path/to/printable
```